### PR TITLE
Add monitor_speed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,3 +11,4 @@
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
+monitor_speed = 115200


### PR DESCRIPTION
On my computer, platform.io used 9600 bps as default so the serial monitor was not readable.